### PR TITLE
Add prompt_toolkit to setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "pwinput",
         "pyperclip",
         "colorama",
+        "prompt_toolkit"
     ],
     entry_points={
         "console_scripts": [
@@ -21,3 +22,4 @@ setup(
     },
     python_requires=">=3.8",
 )
+


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

The prompt_toolkit module was missing in setup.py and wasnt being installed as dependency and threw an error when running ```hacxgpt```. I also noticed that running scripts\install.bat or scripts\install.sh while being inside scripts\ as current directory made it not find setup.py and threw an error, so scripts\install.bat or .sh must be ran outside of scripts.
Fixes # (issue)
I added prompt_toolkit to install_requires.
## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Test A: Installed through install.bat and ran hacxgpt. No errors or warings found.
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
